### PR TITLE
Add support for rq-scheduler via get_scheduler() function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Returns a worker for default queue or specific queues for names given as argumen
 ``get_scheduler`` function
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-If `RQ-Scheduler <https://github.com/ui/rq-scheduler>` is installed this returns a scheduler bound to Flask-RQ's connection
+If `RQ-Scheduler <https://github.com/ui/rq-scheduler>`_ is installed this returns a scheduler bound to Flask-RQ's connection
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,21 @@ Returns a worker for default queue or specific queues for names given as argumen
     get_worker('default', 'low').work(True)
     # Note: These queues have to share the same connection
 
+``get_scheduler`` function
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If `RQ-Scheduler <https://github.com/ui/rq-scheduler>` is installed this returns a scheduler bound to Flask-RQ's connection
+
+.. code-block:: python
+
+    from flask.ext.rq import get_scheduler
+
+    get_scheduler(interval=5).schedule(scheduled_time=datetime.utcnow(),
+                                 func=process,
+                                 interval=10,
+                                 repeat=None)
+    get_scheduler().run()
+
 
 Configuration
 -------------

--- a/flask_rq.py
+++ b/flask_rq.py
@@ -73,6 +73,20 @@ def get_worker(*queues):
         connection=get_connection(queues[0]))
 
 
+try:
+    from rq_scheduler import Scheduler
+
+    def get_scheduler(name='default', interval=60):
+        """
+        Returns an RQ Scheduler instance using parameters defined in
+        ``RQ_QUEUES``
+        """
+        return Scheduler(name, interval=interval,
+                         connection=get_connection(name))
+except ImportError:
+    def get_scheduler(*args, **kwargs):
+        raise ImportError('rq_scheduler not installed')
+
 def job(func_or_queue=None):
     if callable(func_or_queue):
         func = func_or_queue

--- a/tests/flaskrq_tests.py
+++ b/tests/flaskrq_tests.py
@@ -4,7 +4,7 @@ import unittest
 from flask import Flask
 from flask_rq import RQ, config_value, get_connection, get_queue, \
     get_server_url, get_worker, get_scheduler
-from jobs import simple, specified
+from .jobs import simple, specified
 
 
 class config:
@@ -76,11 +76,9 @@ class RQTestCase(unittest.TestCase):
             from rq_scheduler import Scheduler
             scheduler = get_scheduler()
             self.assertIsInstance(scheduler, Scheduler)
-            print "a"
         except ImportError:
             with self.assertRaises(ImportError):
                 get_scheduler()
-            print "b"
 
     def setUp(self):
         self.app = create_app()

--- a/tests/flaskrq_tests.py
+++ b/tests/flaskrq_tests.py
@@ -3,8 +3,8 @@ import unittest
 
 from flask import Flask
 from flask_rq import RQ, config_value, get_connection, get_queue, \
-    get_server_url, get_worker
-from .jobs import simple, specified
+    get_server_url, get_worker, get_scheduler
+from jobs import simple, specified
 
 
 class config:
@@ -17,7 +17,6 @@ def create_app():
     app.config.from_object(config)
     RQ(app)
     return app
-
 
 class RQTestCase(unittest.TestCase):
     def test_config_default_value_db(self):
@@ -71,6 +70,17 @@ class RQTestCase(unittest.TestCase):
     def test_get_worker_low(self):
         worker = get_worker('low')
         self.assertEqual(worker.queues[0].name, 'low')
+
+    def test_get_scheduler(self):
+        try:
+            from rq_scheduler import Scheduler
+            scheduler = get_scheduler()
+            self.assertIsInstance(scheduler, Scheduler)
+            print "a"
+        except ImportError:
+            with self.assertRaises(ImportError):
+                get_scheduler()
+            print "b"
 
     def setUp(self):
         self.app = create_app()


### PR DESCRIPTION
Integrates rq-scheduler (if available) via a new function get_scheduler. Mostly useful for running periodic jobs via flask-script. Code is largely copied from django-rq
