### PR TITLE
Use app context when performing job

### DIFF
--- a/flask_rq.py
+++ b/flask_rq.py
@@ -107,8 +107,7 @@ class RQ(object):
 
 
 class FlaskRQWorker(Worker):
-    def __init__(self, flask_app, *args, **kwargs):
-        self._flask_app = flask_app
+    def __init__(self, *args, **kwargs):
         return super(FlaskRQWorker, self).__init__(*args, **kwargs)
 
     def perform_job(self, *args, **kwargs):


### PR DESCRIPTION
Based on #26, fixes #10, related to #3 

This PR should make sure we use the Flask app's `app_context` when performing a job. This allows you to access stuff like `flask.url_for` etc.

Changes: 
- Register the `app` on module global `_flask_app`
- Use that variable instead of `current_app` so you can access the config without app context present.
- Subclass `rq.Worker` to use the app context in `FlaskRQWorker.perform_job`
