### PR TITLE
Note python3 support in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
See #28. 

Right now, the caniusepython3 script fails on this project.

```
$ pip install caniusepython3
$ caniusepython3 -r requirements.txt

You need 2 projects to transition to Python 3.
Of those 2 projects, 2 have no direct dependencies blocking their transition:

  flask-rq
  flask-sslify
```

From [the documentation](https://github.com/brettcannon/caniusepython3/blob/master/README.md)

> # How do you tell if a project has been ported to Python 3?
> 
> On PyPI each project can specify various trove classifiers (typically in a project's setup.py through a classifier argument to setup()). There are various classifiers related to what version of Python a project can run on. E.g.:
> 
> Programming Language :: Python :: 3
> Programming Language :: Python :: 3.0
> Programming Language :: Python :: 3.1
> Programming Language :: Python :: 3.2
> Programming Language :: Python :: 3.3
> Programming Language :: Python :: 3.4
> As long as a trove classifier for some version of Python 3 is specified then the project is considered to support Python 3 (project owners: it is preferred you at least specify Programming Language :: Python :: 3 as that is how you end up listed on the Python 3 Packages list on PyPI; you can represent Python 2 support with Programming Language :: Python).
