### PR TITLE
fix `RQ_CONNECTION` URL string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unreleased
 
+- Fix error when `RQ_CONNECTION` is a URL string instead of a dict.
+
 ## Version 0.3.0
 
 Released 2025-03-04

--- a/src/flask_rq/_make.py
+++ b/src/flask_rq/_make.py
@@ -42,8 +42,7 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
     if is_async is None:
         is_async = not app.testing
 
-    default_conn = conn_cls(**conn_confs.pop("default", {}))  # type: ignore[arg-type]
-    connections: dict[str, Redis] = {"default": default_conn}
+    connections: dict[str, Redis] = {}
     conn_refs: dict[str, str] = {}
 
     # Collect connections by name first. This allows using forward references to
@@ -62,6 +61,11 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
                 connections[name] = conn_cls.from_url(conn_conf)  # pyright: ignore
         else:
             connections[name] = conn_cls(**conn_conf)
+
+    if "default" in connections:
+        default_conn = connections["default"]
+    else:
+        connections["default"] = default_conn = conn_cls()
 
     job_class = make_job_class(app)
     queues: dict[str, Queue] = {

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ async = [
 
 [[package]]
 name = "flask-rq"
-version = "0.3.0"
+version = "0.3.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "flask", extra = ["async"] },


### PR DESCRIPTION
Missed this while supporting compat with old config. The code handled the default connection early and assumed that the config value was always was a dict. Now the loop that handles all the other connections also handles the default.