### PR TITLE
fix quart import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unreleased
 
+- Remove non-optional `quart` import.
+
 ## Version 0.3.1
 
 Released 2025-03-04

--- a/src/flask_rq/_make.py
+++ b/src/flask_rq/_make.py
@@ -4,13 +4,13 @@ import typing as t
 from pkgutil import resolve_name
 
 from flask import Flask
-from quart import Quart
 from redis.connection import parse_url
 from rq import Queue
 
 from flask_rq._job_class import make_job_class
 
 if t.TYPE_CHECKING:
+    from quart import Quart
     from redis import Redis
 
 


### PR DESCRIPTION
The Quart import is only used for typing. It was present at runtime but Quart is an optional dependency. Move it to the type checking block.