### PR TITLE
Fix breaking change in rq-2.3.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unreleased
 
+- Compatibility with RQ 2.3.3. {issue}`51`
+
 ## Version 0.3.2
 
 Released 2025-03-14

--- a/src/flask_rq/_cli.py
+++ b/src/flask_rq/_cli.py
@@ -7,7 +7,7 @@ import typing_extensions as te
 from click.decorators import _param_memo  # pyright: ignore
 from flask import Flask
 from flask.cli import ScriptInfo as FlaskScriptInfo
-from rq.cli import cli as orig_cli
+from rq import cli as orig_cli
 
 if t.TYPE_CHECKING:
     from quart import Quart
@@ -65,7 +65,7 @@ def rq_group(ctx: click.Context) -> None:
 
 
 @from_rq_cmd(
-    orig_cli.worker,
+    orig_cli.worker,  # type: ignore[attr-defined]
     {
         "burst",
         "name",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import click
 import pytest
 from flask import Flask
 from flask.globals import app_ctx
-from rq.cli import cli as orig_cli
+from rq import cli as orig_cli
 
 from flask_rq import RQ
 from flask_rq._cli import from_rq_cmd
@@ -34,16 +34,16 @@ def test_ctx_obj(app: Flask, rq: RQ) -> None:
 
 
 def test_from_rq_cmd() -> None:
-    @from_rq_cmd(orig_cli.worker, {"queues"})
+    @from_rq_cmd(orig_cli.worker, {"queues"})  # type: ignore[attr-defined]
     def worker(**kwargs: t.Any) -> None:  # pragma: no cover
         pass
 
-    assert worker.__doc__ == orig_cli.worker.__doc__
+    assert worker.__doc__ == orig_cli.worker.__doc__  # type: ignore[attr-defined]
     assert worker.__click_params__[0].name == "queues"  # type: ignore[attr-defined]
 
 
 def test_from_rq_cmd_override_doc() -> None:
-    @from_rq_cmd(orig_cli.worker, {"queues"})
+    @from_rq_cmd(orig_cli.worker, {"queues"})  # type: ignore[attr-defined]
     def worker(**kwargs: t.Any) -> None:  # pragma: no cover
         """override"""
 


### PR DESCRIPTION
This fixes a breaking change in RQ where the internal location of the `worker` method was moved from `rq.cli.cli.worker` to `rq.cli.worker.worker`. The import was also available as `rq.cli.worker` in past and present versions of RQ so we have changed to referencing it from there.

Fixes #51