### PR TITLE
fix how queue order is handled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Unreleased
     - The "flat" config is not used.
     - The `@job` decorator `delay` function is renamed to `enqueue`.
     - `__version__` is removed.
+- The `"default"` queue is not configured automatically if `RQ_QUEUES` is set,
+  it must be listed in that case. {issue}`53`
+- The worker uses the order in `RQ_QUEUES` rather than putting `"default"`
+  first. The first queue's connection is used, rather than the default's.
+  {issue}`53`
 
 ## Version 0.3.3
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,9 +18,15 @@ server. This can be a URL string or a dict of arguments to pass to
 :type: list[str] | None
 :value: ["default"]
 
-The names of the RQ queues to manage. `"default"` will always be available even
-if it is not listed. Each queue will use the default connection
-{data}`RQ_CONNECTION` unless it is overrdden in {data}`RQ_QUEUE_CONNECTIONS`.
+The names of the RQ queues to manage, in priority order. Each queue will use the
+default connection {data}`RQ_CONNECTION` unless it is overrdden in
+{data}`RQ_QUEUE_CONNECTIONS`.
+
+By default, a single `"default"` queue is configured. If you pass a list of
+names, you must include `"default"` if you want to access {attr}`.RQ.queue`.
+
+.. versionchanged:: 1.0
+    `"default"` is not added automatically if other names are listed.
 ```
 
 ```{data} RQ_ASYNC

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -12,16 +12,15 @@ By default, with no configuration, Flask-RQ uses the `"default"` queue and
 connects to a local Redis server. This should be fine for most applications.
 
 If you want to use more queues, you must name each one using the
-{data}`.RQ_QUEUES` config. The `"default"` queue is always configured, regardless
-of if it's listed.
+{data}`.RQ_QUEUES` config. You must include `"default"` if you want to access
+{attr}`.RQ.queue`.
 
 ```python
-RQ_QUEUES = ["email", "priority"]
+RQ_QUEUES = ["email", "priority", "default"]
 ```
 
-The above results in three queues (including `"default"`), all using the same
-Redis connection pool. The connection is configured using the
-{data}`.RQ_CONNECTION` config.
+The above results in three queues, all using the same Redis connection pool. The
+connection is configured using the {data}`.RQ_CONNECTION` config.
 
 ```python
 RQ_CONNECTION = "redis://redis.my-app.example"
@@ -91,7 +90,7 @@ use references to share another connection between queues.
 
 ```python
 RQ_CONNECTION = "redis://redis.my-app.example"
-RQ_QUEUES = ["priority", "email", "email-priority"]
+RQ_QUEUES = ["priority", "email", "email-priority", "default"]
 RQ_QUEUE_CONNECTIONS = {
     "email": "redis://email-redis.my-app.example",
     "email-priority": "email"

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -36,7 +36,7 @@ does, but goes through Flask-RQ to create the job class and worker. Pass the
 If you need to customize the worker beyond what the CLI enables, you can write a
 Python script to create and run the worker. The script must import your app and
 the extension, create an app context, and then call {meth}`.RQ.make_worker`.
-You can pass whaterver arguments you need to `make_worker` and the worker's
+You can pass whatever arguments you need to `make_worker` and the worker's
 `work` method, and do any other customizations you need during the script.
 
 ```python
@@ -56,13 +56,13 @@ $ python my_worker.py
 
 ## Queues and the Connection
 
-By default, the worker will watch all configured queues ({data}`RQ_QUEUES`)
-using the default queue's connection. You can pass a list of queues to the CLI
+By default, the worker will watch all configured queues ({data}`RQ_QUEUES`) in
+the order configured. You can pass a list of queues to the CLI
 command or {meth}`RQ.make_worker`, in which case the worker will only watch
-those queues using the first listed queue's connection.
+those queues. Either way, the first listed queue's connection is used.
 
 ```
-# all queues, default's connection
+# all queues, first configured queue's connection
 $ flask rq worker
 
 # two queues, email's connection

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -122,13 +122,10 @@ class RQ:
         known_queues = self._queues[app]
         worker_queues: list[Queue] = []
 
-        if not queues:
-            known_queues = known_queues.copy()
-            # Default queue is first so its connection is used.
-            worker_queues.append(known_queues.pop("default"))
-            worker_queues.extend(known_queues.values())
-        else:
+        if queues:
             worker_queues.extend(known_queues[k] for k in queues)
+        else:
+            worker_queues.extend(known_queues.values())
 
         return Worker(worker_queues, job_class=worker_queues[0].job_class, **kwargs)
 

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -127,7 +127,12 @@ class RQ:
         else:
             worker_queues.extend(known_queues.values())
 
-        return Worker(worker_queues, job_class=worker_queues[0].job_class, connection=known_queues["default"], **kwargs)
+        return Worker(
+            worker_queues,
+            job_class=worker_queues[0].job_class,
+            connection=known_queues["default"],
+            **kwargs,
+        )
 
     @t.overload
     def job(self, f: t.Callable[P, R], *, queue: str = ...) -> JobWrapper[P, R]: ...

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -121,16 +121,19 @@ class RQ:
         app = self._get_current_app()
         known_queues = self._queues[app]
         worker_queues: list[Queue] = []
+        worker_connection = known_queues["default"].connection
 
         if queues:
             worker_queues.extend(known_queues[k] for k in queues)
+            if "default" not in queues:
+                worker_connection = known_queues[queues[0]].connection
         else:
             worker_queues.extend(known_queues.values())
 
         return Worker(
             worker_queues,
             job_class=worker_queues[0].job_class,
-            connection=known_queues["default"].connection,
+            connection=worker_connection,
             **kwargs,
         )
 

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -127,7 +127,7 @@ class RQ:
         else:
             worker_queues.extend(known_queues.values())
 
-        return Worker(worker_queues, job_class=worker_queues[0].job_class, **kwargs)
+        return Worker(worker_queues, job_class=worker_queues[0].job_class, connection=known_queues["default"], **kwargs)
 
     @t.overload
     def job(self, f: t.Callable[P, R], *, queue: str = ...) -> JobWrapper[P, R]: ...

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -130,7 +130,7 @@ class RQ:
         return Worker(
             worker_queues,
             job_class=worker_queues[0].job_class,
-            connection=known_queues["default"],
+            connection=known_queues["default"].connection,
             **kwargs,
         )
 

--- a/src/flask_rq/_make.py
+++ b/src/flask_rq/_make.py
@@ -53,14 +53,9 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
     job_class = make_job_class(app)
     queues: dict[str, Queue] = {}
 
-    if "default" not in config.get("queues", []):
-        queues["default"] = Queue(
-            "default", default_conn, is_async=is_async, job_class=job_class
-        )
-
     # All defined connections have been created, now create each queue with the
     # connection it references.
-    for name in config.get("queues", []):
+    for name in config.get("queues", ["default"]):
         if name in connections:
             conn = connections[name]
         elif name in conn_refs:

--- a/src/flask_rq/_make.py
+++ b/src/flask_rq/_make.py
@@ -61,7 +61,6 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
     # All defined connections have been created, now create each queue with the
     # connection it references.
     for name in config.get("queues", []):
-
         if name in connections:
             conn = connections[name]
         elif name in conn_refs:

--- a/src/flask_rq/_make.py
+++ b/src/flask_rq/_make.py
@@ -51,17 +51,16 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
 
     default_conn = connections["default"]
     job_class = make_job_class(app)
-    queues: dict[str, Queue] = {
-        "default": Queue(
+    queues: dict[str, Queue] = {}
+
+    if "default" not in config.get("queues", []):
+        queues["default"] = Queue(
             "default", default_conn, is_async=is_async, job_class=job_class
         )
-    }
 
     # All defined connections have been created, now create each queue with the
     # connection it references.
     for name in config.get("queues", []):
-        if name == "default":
-            continue
 
         if name in connections:
             conn = connections[name]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -82,7 +82,7 @@ class ConfigQueueOrderBase:
 
     @pytest.fixture
     def config(self, config: dict[str, t.Any], redis_port: int) -> dict[str, t.Any]:
-        reference_connections = {
+        reference_connections: dict[str, dict[str, t.Any] | str | None] = {
             "low": {"port": redis_port, "db": 1},
             "high": f"redis://localhost:{redis_port}/2",
             "share_low": "low",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -92,7 +92,7 @@ class TestConfigQueueOrderBase:
         config["RQ_QUEUES"] = self.config_queue
         config["RQ_QUEUE_CONNECTIONS"] = self.config_queue_connections
         return config
-    
+
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_no_param(self, rq: RQ) -> None:
         worker = rq.make_worker()
@@ -124,8 +124,8 @@ class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):
 
 
 class TestConfigQueueDefaultPresentNotFirst(TestConfigQueueOrderBase):
-    testing_config_queue = [ "high","default", "low"]
+    testing_config_queue = ["high", "default", "low"]
 
 
 class TestConfigQueueDefaultNotPresent(TestConfigQueueOrderBase):
-    testing_config_queue = [ "high", "low"]
+    testing_config_queue = ["high", "low"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -73,12 +73,12 @@ def test_worker_queues(rq: RQ) -> None:
 
 
 class ConfigQueueOrderBase:
-    config_queue = []
-    expected_config_queue_returned = []
-    config_queue_connections = {}
-    param_queue_default_provided_first = ["default", "high"]
-    param_queue_default_provided = ["high", "default"]
-    param_queue_default_not_provided = ["high", "low"]
+    config_queue:list[str] = []
+    expected_config_queue_returned:list[str] = []
+    config_queue_connections:dict[str, dict[str, t.Any] | str | None] = {}
+    param_queue_default_provided_first:list[str] = ["default", "high"]
+    param_queue_default_provided:list[str] = ["high", "default"]
+    param_queue_default_not_provided:list[str] = ["high", "low"]
 
     @pytest.fixture
     def config(self, config: dict[str, t.Any], redis_port: int) -> dict[str, t.Any]:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -87,8 +87,12 @@ class TestConfigQueueOrderBase:
             "share_low": "low",
             "plain": None,
         }
-        self.config_queue_connections = {key: value for key, value in reference_connections.items() if key in self.config_queue}
-        
+        self.config_queue_connections = {
+            key: value
+            for key, value in reference_connections.items()
+            if key in self.config_queue
+        }
+
         config["RQ_QUEUES"] = self.config_queue
         config["RQ_QUEUE_CONNECTIONS"] = self.config_queue_connections
         return config
@@ -120,7 +124,6 @@ class TestConfigQueueOrderBase:
 
 class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):
     testing_config_queue = ["default", "high", "low"]
-
 
 
 class TestConfigQueueDefaultPresentNotFirst(TestConfigQueueOrderBase):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -123,12 +123,12 @@ class TestConfigQueueOrderBase:
 
 
 class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):
-    testing_config_queue = ["default", "high", "low"]
+    config_queue = ["default", "high", "low"]
 
 
 class TestConfigQueueDefaultPresentNotFirst(TestConfigQueueOrderBase):
-    testing_config_queue = ["high", "default", "low"]
+    config_queue = ["high", "default", "low"]
 
 
 class TestConfigQueueDefaultNotPresent(TestConfigQueueOrderBase):
-    testing_config_queue = ["high", "low"]
+    config_queue = ["high", "low"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -115,7 +115,7 @@ class TestConfigQueueOrderBase:
         assert worker.queue_names() == self.param_queue_default_provided
         assert (
             worker.connection
-            is rq.queues[self.param_queue_default_provided[0]].connection
+            is rq.queues["default"].connection
         )
 
     @pytest.mark.usefixtures("app_ctx")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -113,10 +113,7 @@ class TestConfigQueueOrderBase:
     def test_worker_param_default_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_provided)
         assert worker.queue_names() == self.param_queue_default_provided
-        assert (
-            worker.connection
-            is rq.queues["default"].connection
-        )
+        assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_param_default_provided_first(self, rq: RQ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -112,19 +112,19 @@ class TestConfigQueueOrderBase:
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_param_default_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_provided)
-        assert worker.queues == self.param_queue_default_provided
+        assert worker.queue_names() == self.param_queue_default_provided
         assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_param_default_provided_first(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_provided_first)
-        assert worker.queues == self.param_queue_default_provided_first
+        assert worker.queue_names() == self.param_queue_default_provided_first
         assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_param_default_not_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_not_provided)
-        assert worker.queues == self.param_queue_default_not_provided
+        assert worker.queue_names() == self.param_queue_default_not_provided
         assert worker.connection is rq.queues["default"].connection
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -103,7 +103,7 @@ class TestConfigQueueOrderBase:
     def test_worker_no_param(self, rq: RQ) -> None:
         worker = rq.make_worker()
         assert (
-            worker.queues == self.config_queue
+            worker.queue_names() == self.config_queue
             if self.config_queue != []
             else ["default"]
         )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -100,7 +100,11 @@ class TestConfigQueueOrderBase:
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_no_param(self, rq: RQ) -> None:
         worker = rq.make_worker()
-        assert worker.queues == self.config_queue if self.config_queue != [] else ["default"]
+        assert (
+            worker.queues == self.config_queue
+            if self.config_queue != []
+            else ["default"]
+        )
         assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -125,9 +125,7 @@ class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):
 
 class TestConfigQueueDefaultPresentNotFirst(TestConfigQueueOrderBase):
     testing_config_queue = [ "high","default", "low"]
-    config_queue_connections
 
 
 class TestConfigQueueDefaultNotPresent(TestConfigQueueOrderBase):
     testing_config_queue = [ "high", "low"]
-    config_queue_connections

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -74,7 +74,7 @@ def test_worker_queues(rq: RQ) -> None:
 
 class TestConfigQueueEmpty:
     config_queue: list[str] = []
-    expected_config_queue_returned: list[str] = []
+    expected_config_queue_returned: list[str] = ["default"]
     config_queue_connections: dict[str, dict[str, t.Any] | str | None] = {}
     param_queue_default_provided_first: list[str] = ["default", "high"]
     param_queue_default_provided: list[str] = ["high", "default"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -104,6 +104,7 @@ class TestConfigQueueEmpty:
         assert worker.queue_names() == self.expected_config_queue_returned
         assert worker.connection is rq.queues["default"].connection
 
+
 class ConfigQueueOrderBase:
     config_queue: list[str] = []
     expected_config_queue_returned: list[str] = []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -72,7 +72,7 @@ def test_worker_queues(rq: RQ) -> None:
     assert worker.connection is rq.queues["low"].connection
 
 
-class TestConfigQueueOrderBase:
+class ConfigQueueOrderBase:
     config_queue = []
     config_queue_connections = {}
     param_queue_default_provided_first = ["default", "high"]
@@ -131,13 +131,13 @@ class TestConfigQueueOrderBase:
         )
 
 
-class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):
+class TestConfigQueueDefaultProvidedFirst(ConfigQueueOrderBase):
     config_queue = ["default", "high", "low"]
 
 
-class TestConfigQueueDefaultPresentNotFirst(TestConfigQueueOrderBase):
+class TestConfigQueueDefaultPresentNotFirst(ConfigQueueOrderBase):
     config_queue = ["high", "default", "low"]
 
 
-class TestConfigQueueDefaultNotPresent(TestConfigQueueOrderBase):
+class TestConfigQueueDefaultNotPresent(ConfigQueueOrderBase):
     config_queue = ["high", "low"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -73,12 +73,12 @@ def test_worker_queues(rq: RQ) -> None:
 
 
 class ConfigQueueOrderBase:
-    config_queue:list[str] = []
-    expected_config_queue_returned:list[str] = []
-    config_queue_connections:dict[str, dict[str, t.Any] | str | None] = {}
-    param_queue_default_provided_first:list[str] = ["default", "high"]
-    param_queue_default_provided:list[str] = ["high", "default"]
-    param_queue_default_not_provided:list[str] = ["high", "low"]
+    config_queue: list[str] = []
+    expected_config_queue_returned: list[str] = []
+    config_queue_connections: dict[str, dict[str, t.Any] | str | None] = {}
+    param_queue_default_provided_first: list[str] = ["default", "high"]
+    param_queue_default_provided: list[str] = ["high", "default"]
+    param_queue_default_not_provided: list[str] = ["high", "low"]
 
     @pytest.fixture
     def config(self, config: dict[str, t.Any], redis_port: int) -> dict[str, t.Any]:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -96,7 +96,7 @@ class TestConfigQueueOrderBase:
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_no_param(self, rq: RQ) -> None:
         worker = rq.make_worker()
-        assert worker.queues == self.config_queue
+        assert worker.queues == self.config_queue if self.config_queue != [] else ["default"]
         assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -113,7 +113,7 @@ class TestConfigQueueOrderBase:
     def test_worker_param_default_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_provided)
         assert worker.queue_names() == self.param_queue_default_provided
-        assert worker.connection is rq.queues["default"].connection
+        assert worker.connection is rq.queues[self.param_queue_default_provided[0]].connection
 
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_param_default_provided_first(self, rq: RQ) -> None:
@@ -125,7 +125,7 @@ class TestConfigQueueOrderBase:
     def test_worker_param_default_not_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_not_provided)
         assert worker.queue_names() == self.param_queue_default_not_provided
-        assert worker.connection is rq.queues["default"].connection
+        assert worker.connection is rq.queues[self.param_queue_default_not_provided[0]].connection
 
 
 class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -113,7 +113,10 @@ class TestConfigQueueOrderBase:
     def test_worker_param_default_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_provided)
         assert worker.queue_names() == self.param_queue_default_provided
-        assert worker.connection is rq.queues[self.param_queue_default_provided[0]].connection
+        assert (
+            worker.connection
+            is rq.queues[self.param_queue_default_provided[0]].connection
+        )
 
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_param_default_provided_first(self, rq: RQ) -> None:
@@ -125,7 +128,10 @@ class TestConfigQueueOrderBase:
     def test_worker_param_default_not_provided(self, rq: RQ) -> None:
         worker = rq.make_worker(self.param_queue_default_not_provided)
         assert worker.queue_names() == self.param_queue_default_not_provided
-        assert worker.connection is rq.queues[self.param_queue_default_not_provided[0]].connection
+        assert (
+            worker.connection
+            is rq.queues[self.param_queue_default_not_provided[0]].connection
+        )
 
 
 class TestConfigQueueDefaultProvidedFirst(TestConfigQueueOrderBase):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -104,8 +104,6 @@ class ConfigQueueOrderBase:
         worker = rq.make_worker()
         assert (
             worker.queue_names() == self.config_queue
-            if self.config_queue != []
-            else ["default"]
         )
         assert worker.connection is rq.queues["default"].connection
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -74,6 +74,7 @@ def test_worker_queues(rq: RQ) -> None:
 
 class ConfigQueueOrderBase:
     config_queue = []
+    expected_config_queue_returned = []
     config_queue_connections = {}
     param_queue_default_provided_first = ["default", "high"]
     param_queue_default_provided = ["high", "default"]
@@ -102,7 +103,7 @@ class ConfigQueueOrderBase:
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_no_param(self, rq: RQ) -> None:
         worker = rq.make_worker()
-        assert worker.queue_names() == self.config_queue
+        assert worker.queue_names() == self.expected_config_queue_returned
         assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")
@@ -129,11 +130,14 @@ class ConfigQueueOrderBase:
 
 class TestConfigQueueDefaultProvidedFirst(ConfigQueueOrderBase):
     config_queue = ["default", "high", "low"]
+    expected_config_queue_returned = ["default", "high", "low"]
 
 
 class TestConfigQueueDefaultPresentNotFirst(ConfigQueueOrderBase):
     config_queue = ["high", "default", "low"]
+    expected_config_queue_returned = ["high", "default", "low"]
 
 
 class TestConfigQueueDefaultNotPresent(ConfigQueueOrderBase):
     config_queue = ["high", "low"]
+    expected_config_queue_returned = ["default", "high", "low"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -102,9 +102,7 @@ class ConfigQueueOrderBase:
     @pytest.mark.usefixtures("app_ctx")
     def test_worker_no_param(self, rq: RQ) -> None:
         worker = rq.make_worker()
-        assert (
-            worker.queue_names() == self.config_queue
-        )
+        assert worker.queue_names() == self.config_queue
         assert worker.connection is rq.queues["default"].connection
 
     @pytest.mark.usefixtures("app_ctx")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -94,7 +94,9 @@ class TestConfigQueueOrderBase:
         }
 
         config["RQ_QUEUES"] = self.config_queue
+        print(config["RQ_QUEUES"])
         config["RQ_QUEUE_CONNECTIONS"] = self.config_queue_connections
+        print(config["RQ_QUEUE_CONNECTIONS"])
         return config
 
     @pytest.mark.usefixtures("app_ctx")


### PR DESCRIPTION

This PR retains the behavior where the default will be first if not defined. But will respect the order if it is defined in the config. There may not be a need to retain behavior for the default as the first 

Fixes #53 

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
-->
