### PR TITLE
add RQ's Cron scheduler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Unreleased
   {issue}`53`
 - Support RQ's Cron scheduler. The `flask rq cron` CLI command starts the
   scheduler.
+- Add `enqueue_at`, `enqueue_in`, and `cron_register` methods to the `@job`
+  wrapper.
 
 ## Version 0.3.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Unreleased
 
 - Drop support for Python 3.9.
+- Require RQ >= 2.4.
 - Remove previously deprecated code. Use 0.3 as an intermediate upgrade to see
   deprecation warnings.
     - The global API (`get_queue`, `get_worker`, `@job`) is removed.
@@ -14,6 +15,8 @@ Unreleased
 - The worker uses the order in `RQ_QUEUES` rather than putting `"default"`
   first. The first queue's connection is used, rather than the default's.
   {issue}`53`
+- Support RQ's Cron scheduler. The `flask rq cron` CLI command starts the
+  scheduler.
 
 ## Version 0.3.3
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,12 +14,19 @@ or private and may change at any time.
 
 .. class:: JobWrapper
 
-    The wrapper returned when using the :class:`RQ.job <flask_rq.RQ.job>`
-    decorator. This class itself is not part of the public API, and should not
-    be imported directly. The methods documented below are part of the public
-    API.
+    The wrapper returned when using the :class:`~.RQ.job` decorator. This class
+    itself is not part of the public API, and should not be imported directly.
+    The members documented below are part of the public API.
 
     .. automethod:: enqueue
 
+    .. automethod:: enqueue_at
+
+    .. automethod:: enqueue_in
+
+    .. automethod:: cron_register
+
     .. automethod:: __call__
+
+    .. autoattribute:: func
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,8 +25,9 @@ default connection {data}`RQ_CONNECTION` unless it is overrdden in
 By default, a single `"default"` queue is configured. If you pass a list of
 names, you must include `"default"` if you want to access {attr}`.RQ.queue`.
 
-.. versionchanged:: 1.0
-    `"default"` is not added automatically if other names are listed.
+:::{versionchanged} 1.0
+`"default"` is not added automatically if other names are listed.
+:::
 ```
 
 ```{data} RQ_ASYNC

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,9 +9,9 @@ Configuration for Flask-RQ uses the following Flask config keys.
 :type: str | dict[str, typing.Any] | None
 :value: "redis://127.0.0.1:6379/0"
 
-The default Redis connection to use for each queue. The default assumes a local
-server. This can be a URL string or a dict of arguments to pass to
-{data}`RQ_CONNECTION_CLASS`.
+The default Redis connection to use for each queue, and for the Cron scheduler.
+The default assumes a local server. This can be a URL string or a dict of
+arguments to pass to {data}`RQ_CONNECTION_CLASS`.
 ```
 
 ```{data} RQ_QUEUES

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,16 @@
 # Flask-RQ
 
 Flask-RQ is a [Flask]/[Quart] extension that background job execution using
-[RQ]. RQ allows queueing functions to be run in separate worker processes,
+[RQ].
+
+RQ allows queueing functions to be run in separate worker processes,
 allowing long-running jobs to run in the background without blocking the web app
-from returning a response quickly. Flask-RQ allows configuring RQ using Flask's
-config, and handles executing jobs in the application context, so other services
-like database connections are available.
+from returning a response quickly. RQ also provides Cron support for scheduling
+periodic jobs.
+
+Flask-RQ allows configuring RQ using Flask's config, and handles executing jobs
+in the application context, so other services like database connections are
+available.
 
 [Flask]: https://flask.palletsprojects.com
 [Quart]: https://quart.palletsprojects.com
@@ -32,6 +37,7 @@ start
 config
 queue
 job
+schedule
 worker
 server
 testing

--- a/docs/job.md
+++ b/docs/job.md
@@ -32,6 +32,9 @@ Both sync `def` and `async def` functions can be queued in the same way. Behind
 the scenes, Flask-RQ will add the appropriate wrapper to activate the app
 context, and the RQ worker will start an asyncio event loop if needed.
 
+Jobs can be scheduled to run in the future or periodically. See {doc}`schedule`
+for more information.
+
 ## The `job` Decorator
 
 The {meth}`.RQ.job` decorator wraps a function to give it an
@@ -59,6 +62,21 @@ The wrapped function can still be called as a plain function as well.
 await send_password_reset(user_id=user.id)
 ```
 
+:::{warning}
+Due to the way RQ references jobs, it's not possible to pass decorated jobs to
+`queue.enqueue` or other functions.
+
+Either use the wrapper's methods, or pass its {attr}`~.JobWrapper.func`
+attribute.
+
+```python
+send_reminder.cron_register("0 0 * * 1-5")
+
+# same as
+rq.cron.register(send_reminder.func, cron="0 0 * * 1-5")
+```
+:::
+
 ## Async
 
 Flask-RQ supports both Flask and Quart, and sync and async job functions. RQ
@@ -72,31 +90,3 @@ that it is still an issue, or look into contributing async support to RQ.
 ```python
 await asyncio.to_thread(rq.enqueue, send_password_reset, user_id=user.id)
 ```
-
-## Scheduled Jobs
-
-RQ queues have two more methods that will enqueue the job to run at a specified
-time.
-
-- `rq.queue.enqueue_at(datetime, func, ...)` - a worker will execute the
-  function at the given {class}`~datetime.datetime`.
-- `rq.queue.enqueue_in(timedelta, func, ...` - a worker will execute the
-  function after the given {class}`~datetime.timedelta` interval has passed.
-
-This requires running at least one worker with the scheduler enabled. Running
-multiple workers with the scheduler is also ok.
-
-```
-$ flask rq worker --with-scheduler
-```
-
-RQ does not currently provide a way to run jobs on a repeated interval or Cron
-schedule. [RQ-Scheduler][] provides separate commands for doing so, but Flask-RQ
-does not yet provide integration, so any jobs will not be run in the app context
-automatically.
-
-[RQ-Scheduler]: https://github.com/rq/rq-scheduler
-
-It is possible to schedule repeat intervals without RQ-Scheduler by
-having a job enqueue itself again after running. You can use RQ's job callback
-feature to ensure it's rescheduled or retired regardless of success.

--- a/docs/job.md
+++ b/docs/job.md
@@ -12,8 +12,8 @@ view functions and CLI commands.
 ## Queuing a Job
 
 Call a queue's `enqueue` method, passing a job function and any arguments. A
-queue has other methods for scheduling, and some arguments can be give to
-customize the job's information. See the [RQ docs] for more information.
+queue has other methods, and some arguments can be given to customize the job's
+information. See the [RQ docs] for more information.
 
 [RQ docs]: https://python-rq.org/docs/
 
@@ -35,11 +35,12 @@ context, and the RQ worker will start an asyncio event loop if needed.
 Jobs can be scheduled to run in the future or periodically. See {doc}`schedule`
 for more information.
 
+(job-decorator)=
 ## The `job` Decorator
 
-The {meth}`.RQ.job` decorator wraps a function to give it an
-{meth}`enqueue <.JobWorker.enqueue>` method that automatically enqueues the
-function using the extension instance and given queue name.
+The {meth}`.RQ.job` decorator wraps a function to give it enqueue methods that
+use the extension instance and given queue name. See {class}`.JobWrapper` for
+the available methods.
 
 ```python
 @rq.job(queue="email")
@@ -52,11 +53,11 @@ send_password_reset.enqueue(user_id=user.id)
 rq.queues["email"].enqueue(send_password_reset, user_id=user.id)
 ```
 
-This added `enqueue` method retains the static type signature of the wrapped
-function, meaning your type checker can check the call unlike the generic call
-to `queue.enqueue`.
+The added methods retain the static type signature of the wrapped function,
+meaning your type checker can check the call, unlike the generic call to
+`queue.enqueue`.
 
-The wrapped function can still be called as a plain function as well.
+The wrapper can be called to execute the wrapped function directly.
 
 ```python
 await send_password_reset(user_id=user.id)

--- a/docs/job.md
+++ b/docs/job.md
@@ -28,9 +28,7 @@ rq.queue.enqueue(update_stats, data=...)
 rq.queues["email"].enqueue(send_passord_reset, user_id=user.id)
 ```
 
-Both sync `def` and `async def` functions can be queued in the same way. Behind
-the scenes, Flask-RQ will add the appropriate wrapper to activate the app
-context, and the RQ worker will start an asyncio event loop if needed.
+Both sync `def` and `async def` job functions are supported.
 
 Jobs can be scheduled to run in the future or periodically. See {doc}`schedule`
 for more information.
@@ -80,11 +78,14 @@ rq.cron.register(send_reminder.func, cron="0 0 * * 1-5")
 
 ## Async
 
-Flask-RQ supports both Flask and Quart, and sync and async job functions. RQ
-handles sync and async job functions, but only uses the `redis.Redis` sync
-connection to communicate with Redis. You might be concerned that calling
-`enqueue` from an `async def` view function is blocking, but in practice it
-is a very fast operation to make some Redis API calls to record the job
+Flask-RQ supports both Flask and Quart. Sync `def` and `async def` functions can
+be queued in the same way. Behind the scenes, Flask-RQ will add the appropriate
+wrapper to activate the app context, and the RQ worker will start an asyncio
+event loop if needed.
+
+RQ only uses the `redis.Redis` sync connection to communicate with Redis. You
+might be concerned that calling `enqueue` from an `async def` view function is
+blocking, but in practice it is a very fast operation to record the job
 information. You can use {meth}`asyncio.to_thread` to call `enqueue` if you find
 that it is still an issue, or look into contributing async support to RQ.
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -3,7 +3,7 @@
 For many applications, using the single `"default"` queue will be all they ever
 need. That said, RQ allows enqueuing jobs on different named queues. Workers can
 be started watching specific queues, so for example you can start one worker
-watching to the `"default"` queue, and three workers watching the `"priority"`
+watching the `"default"` queue, and three workers watching the `"priority"`
 queue.
 
 ## Configuring Queues

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -42,30 +42,14 @@ rq.queue.enqueue(update_stats, data=...)
 rq.queues["email"].enqueue(send_passord_reset, user_id=user.id)
 ```
 
-## The `job` Decorator
+### The `job` Decorator
 
-The {meth}`.RQ.job` decorator wraps a function to give it an
-{meth}`enqueue <.JobWorker.enqueue>` method that automatically enqueues the
-function using the extension instance and given queue name.
+The {meth}`.RQ.job` decorator wraps a function to give it enqueue methods that
+use the extension instance and given queue name. See {ref}`job-decorator` for
+more information, and {class}`.JobWrapper` for the available methods.
 
-```python
-@rq.job(queue="email")
-def send_password_reset(user_id: int) -> None:
-    ...
-
-send_password_reset.enqueue(user_id=user.id)
-
-# same as
-rq.queues["email"].enqueue(send_password_reset, user_id=user.id)
-```
-
-The queue can be overridden, it only applies when using the added method. The
-following uses the `"priority"` queue even though the job was configured for the
-`"email"` queue.
-
-```python
-rq.queues["priority"].enqueue(send_password_reset, user_id=user.id)
-```
+The given queue only applies when using the added method. It can still be
+passed to another queue's `enqueue` method.
 
 ## Other Connections
 

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -1,0 +1,109 @@
+# Scheduled Jobs
+
+RQ provides two ways to schedule jobs to run in the future and perodically.
+Unfortunately, they both use the name "scheduler", but accomplish different
+goals. Both may run at the same time.
+
+The basic scheduler runs as part of the worker. It allows enqueued jobs to wait
+to run until a specified time. It can repeat jobs a specified finite number of
+times.
+
+The cron scheduler runs as a separate process. It enqueues jobs based
+on configured intervals or schedules. The jobs will repeat periodically until
+the scheduler is stopped.
+
+## Future Jobs
+
+A queue's `enqueue` method runs the job as soon as possible. Two other
+methods are provided to tell workers to wait until a specified time
+before taking the job.
+
+- `rq.queue.enqueue_at(datetime, func, ...)` - A worker will wait until the
+  given {class}`~datetime.datetime` to take the job.
+- `rq.queue.enqueue_in(timedelta, func, ...` - A worker will wait until the
+  given {class}`~datetime.timedelta` interval has passed to take the job.
+
+See the [RQ docs on scheduling](https://python-rq.org/docs/scheduling/) for more
+information.
+
+This requires running at least one worker with the scheduler enabled. Running
+multiple workers with the scheduler is also ok.
+
+```
+$ flask rq worker --with-scheduler
+```
+
+This still requires enqueuing the job from your code. It cannot independently
+enqueue jobs on a schedule. That's what the Cron scheduler is for.
+
+It is possible to schedule continuous intervals without the Cron scheduler by
+having a job enqueue itself again after running. You can use RQ's job callback
+feature to ensure it's rescheduled or retried regardless of success.
+
+### The `job` Decorator
+
+The {meth}`~.RQ.job` decorator provides {meth}`~.JobWrapper.enqueue_at` and
+{meth}`~.JobWrapper.enqueue_in` methods as well. As an extra convenience,
+`enqueue_in` accepts an `int` of seconds or a `timedelta`.
+
+```python
+delete_temporary_files.enqueue_in(30)
+```
+
+## Cron Scheduled Jobs
+
+The Cron scheduler continuously schedules jobs at fixed intervals.
+
+The schedule is defined ahead of time and the scheduler runs as a separate
+process periodically enqueuing jobs according to the schedule. To run the
+scheduler:
+
+```
+$ flask rq cron
+```
+
+Jobs can be scheduled globally with the {func}`rq.cron.register` method. Or
+they can be registered specific to the extension instance with
+{meth}`.RQ.cron_register`. Flask-RQ adds both the global and instance jobs when
+running the scheduler.
+
+RQ's global `register` method takes an `interval` number of seconds between job
+runs, or a `cron` string as interpreted by [croniter] to specify more complex
+intervals. For convenience, the extension's `cron_register` method uses the
+second positional argument for both `interval` and `cron`, and uses the
+`"default"` queue by default.
+
+[croniter]: https://github.com/pallets-eco/croniter
+
+See the [RQ docs on Cron](https://python-rq.org/docs/cron/) for more
+information.
+
+```python
+# global registration, interval seconds
+from rq import cron
+cron.register(update_data_source, "default", interval=28_800)
+
+# app-specific registration, cron string
+rq = RQ(app)
+rq.cron_register(delete_temporary_files, "0 2 * * *")
+```
+
+### The `job` Decorator
+
+The {meth}`~.RQ.job` decorator provides a {meth}`~.JobWrapper.cron_register`
+method as well. As an extra convenience, it uses the first positional argument
+for both `interval` and `cron`.
+
+```python
+update_data_source.cron_register(28_800)
+delete_temporary_files.cron_register("0 2 * * *")
+```
+
+### Legacy RQ-Scheduler Library
+
+Before it was implemented in RQ, Cron support was previously provided by a
+separate [RQ-Scheduler] library. Flask-RQ does not provide integration with
+this, so it will need to be configured manually, and any jobs will not be run in
+the app context. Prefer using RQ's built-in Cron support.
+
+[RQ-Scheduler]: https://github.com/rq/rq-scheduler

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,7 @@
 RQ queues can be set to execute jobs immediately in the local process when
 enqueued, rather than requiring a separate worker process. When `app.testing`
 is `True`, Flask-RQ will enable this mode automatically. It can also be forced
-on or off using the {data}`RQ_ASYNC` config. A Redis server must still be
+on or off using the {data}`.RQ_ASYNC` config. A Redis server must still be
 running in order for RQ to do its bookkeeping.
 
 ## Managing a Test Server
@@ -88,7 +88,7 @@ steps:
 Instead of requiring Redis to be installed and running a real server, you can
 use the connection class provided by the [FakeRedis] library. This provides the
 same API as the Python Redis library, but stores all the data in the local
-Python memory. During testing, change {data}`RQ_CONNECTION_CLASS`.
+Python memory. During testing, change {data}`.RQ_CONNECTION_CLASS`.
 
 ```python
 app.config["RQ_CONNECTION_CLASS"] = "fakeredis.FakeRedis"

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -56,9 +56,9 @@ $ python my_worker.py
 
 ## Queues and the Connection
 
-By default, the worker will watch all configured queues ({data}`RQ_QUEUES`) in
+By default, the worker will watch all configured queues ({data}`.RQ_QUEUES`) in
 the order configured. You can pass a list of queues to the CLI
-command or {meth}`RQ.make_worker`, in which case the worker will only watch
+command or {meth}`.RQ.make_worker`, in which case the worker will only watch
 those queues. Either way, the first listed queue's connection is used.
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [{name = "Pallets Ecosystem", email = "contact@palletsprojects.com
 requires-python = ">=3.10"
 dependencies = [
     "flask[async]>=3.0",
-    "rq>=2.0",
+    "rq>=2.4",
     "typing-extensions>=4.12",
 ]
 

--- a/src/flask_rq/_cli.py
+++ b/src/flask_rq/_cli.py
@@ -29,6 +29,7 @@ def make_cli(app: Flask | Quart) -> None:
     """
     group = app.cli.group("rq")(rq_group)
     group.command("worker", with_appcontext=True)(worker_cmd)
+    group.command("cron", with_appcontext=True)(cron_cmd)
     app.cli.add_command(group)
 
 
@@ -107,3 +108,9 @@ def worker_cmd(
         max_idle_time=max_idle_time,
         with_scheduler=with_scheduler,
     )
+
+
+@from_rq_cmd(orig_cli.cron, set())  # type: ignore[attr-defined]
+@click.pass_obj
+def cron_cmd(obj: RQ) -> None:
+    obj.make_cron_scheduler().start()  # type: ignore[no-untyped-call]

--- a/src/flask_rq/_cli.py
+++ b/src/flask_rq/_cli.py
@@ -4,7 +4,7 @@ import typing as t
 
 import click
 import typing_extensions as te
-from click.decorators import _param_memo  # pyright: ignore
+from click.decorators import _param_memo
 from flask import Flask
 from flask.cli import ScriptInfo as FlaskScriptInfo
 from rq import cli as orig_cli

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -135,22 +135,25 @@ class RQ:
         """Create a worker for the current application that will watch the
         configured queues and execute jobs in the application context.
 
+        Use the ``flask rq worker`` CLI command to create and start a worker.
+        Use this method if you want to manage and start the worker from code,
+        such as in tests.
+
         :param queues: The named queues for the worker to watch, using the first
             queue's connection. By default, uses all the queues in order from
-            :data:`RQ_QUEUES`.
+            :data:`.RQ_QUEUES`.
         :param kwargs: Other arguments to pass to the worker constructor.
 
         .. versionchanged:: 1.0
             Uses order from ``RQ_QUEUES`` instead of forcing ``"default"`` first.
         """
-        app = self._get_current_app()
-        known_queues = self._queues[app]
-        worker_queues: list[Queue] = []
+        worker_queues: cabc.Sequence[Queue]
 
         if not queues:
-            worker_queues.extend(known_queues.values())
+            worker_queues = tuple(self.queues.values())
         else:
-            worker_queues.extend(known_queues[k] for k in queues)
+            known_queues = self.queues
+            worker_queues = tuple(known_queues[k] for k in queues)
 
         return Worker(worker_queues, job_class=worker_queues[0].job_class, **kwargs)
 

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as t
 from weakref import WeakKeyDictionary
 
 import typing_extensions as te
 from flask import Flask
 from flask.globals import app_ctx as flask_app_ctx
+from rq import cron
 from rq import Queue
 from rq import Worker
 
 from ._cli import make_cli
 from ._job_wrapper import JobWrapper
+from ._make import make_default_connection
 from ._make import make_queues
 
 if t.TYPE_CHECKING:
@@ -27,6 +30,7 @@ class RQ:
     """
 
     def __init__(self, app: Flask | Quart | None = None) -> None:
+        self._cron_job_data: list[dict[str, t.Any]] = []
         self._queues: WeakKeyDictionary[Flask | Quart, dict[str, Queue]] = (
             WeakKeyDictionary()
         )
@@ -149,6 +153,62 @@ class RQ:
             worker_queues.extend(known_queues[k] for k in queues)
 
         return Worker(worker_queues, job_class=worker_queues[0].job_class, **kwargs)
+
+    def cron_register(
+        self,
+        f: t.Callable[P, R],
+        /,
+        interval: int | str,
+        *,
+        queue: str = "default",
+        args: cabc.Sequence[t.Any] | None = None,
+        kwargs: cabc.Mapping[str, t.Any] | None = None,
+        **register_kwargs: t.Any,
+    ) -> None:
+        """Register a Cron job specific to this extension instance, as opposed
+        to globally with :func:`rq.cron.register`.
+
+        Use the ``flask rq cron`` CLI command to start the scheduler.
+
+        :param f: The job function.
+        :param interval: An int number of seconds, or a Cron string, descrbing
+            when the job is scheduled.
+        :param queue: The queue the scheduler will submit this job to.
+        :param args: Any positional arguments accepted by the wrapped function.
+        :param kwargs: Any keyword arguments accepted by the wrapped function.
+        :param register_kwargs: Any keyword arguments accepted by
+            {meth}`rq.cron.CronScheduler.register`.
+        """
+        register_kwargs.update(func=f, queue_name=queue, args=args, kwargs=kwargs)
+
+        if isinstance(interval, int):
+            register_kwargs["interval"] = interval
+        else:
+            register_kwargs["cron"] = interval
+
+        self._cron_job_data.append(register_kwargs)
+
+    def make_cron_scheduler(self) -> cron.CronScheduler:
+        """Create a Cron scheduler for the current application.
+
+        Use the ``flask rq cron`` CLI command to start the scheduler. Only use
+        this method directly if you want to start the scheduler from code.
+
+        Has the jobs registered to this extension instance with
+        :meth:`cron_register`, and the jobs registered globally with
+        :func:`rq.cron.register`.
+
+        Uses the default connection configured from :data:`.RQ_CONNECTION`.
+        """
+        app = self._get_current_app()
+        conn = make_default_connection(app)
+        scheduler = cron.create_cron(conn)
+        scheduler.name = app.name
+
+        for item in self._cron_job_data:
+            scheduler.register(**item)
+
+        return scheduler
 
     @t.overload
     def job(self, f: t.Callable[P, R], *, queue: str = ...) -> JobWrapper[P, R]: ...

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -224,9 +224,9 @@ class RQ:
         *,
         queue: str = "default",
     ) -> JobWrapper[P, R] | t.Callable[[t.Callable[P, R]], JobWrapper[P, R]]:
-        """Wrap the decorated function to add an `enqueue` method to it.
-        `job.enqueue()` is a shortcut for `rq.queue.enqueue(job)`. Can be
-        used as a decorator with or without arguments, or as a function.
+        """Wrap the decorated function to add enqueue methods to it. See
+        :class:`.JobWrapper` for the available methods. Can be used as a
+        decorator with or without arguments.
 
         .. code-block:: python
 
@@ -237,8 +237,6 @@ class RQ:
             @rq.job(queue="math")
             def sub(a, b):
                 return a - b
-
-            mul = rq.job(lambda a, b: a * b, queue="math")
 
         :param f: The job function. If not given, return a new decorator that
             uses the other given arguments.

--- a/src/flask_rq/_job_wrapper.py
+++ b/src/flask_rq/_job_wrapper.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import typing as t
+from datetime import datetime
+from datetime import timedelta
 from functools import update_wrapper
 
 import typing_extensions as te
@@ -49,29 +51,57 @@ class JobWrapper(t.Generic[P, R]):
 
         update_wrapper(self, func)
 
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+    def __call__(self, /, *args: P.args, **kwargs: P.kwargs) -> R:
         """Call the wrapped function directly.
-
-        This retains the same static type signature as the wrapped function.
 
         :param args: Any positional arguments accepted by the wrapped function.
         :param kwargs: Any keyword arguments accepted by the wrapped function.
         """
         return self.func(*args, **kwargs)
 
-    def enqueue(self, *args: P.args, **kwargs: P.kwargs) -> Job:
+    def enqueue(self, /, *args: P.args, **kwargs: P.kwargs) -> Job:
         """Submit the wrapped function to the queue for background execution.
-
-        This retains the same static type signature for as the wrapped function,
-        except it returns a :class:`rq.Job` instance.
+        Calls :meth:`rq.Queue.enqueue`.
 
         :param args: Any positional arguments accepted by the wrapped function.
         :param kwargs: Any keyword arguments accepted by the wrapped function,
             along with any keyword arguments that can be passed to
-            :meth:`rq.Queue.enqueue`.
+            ``Queue.enqueue``.
         """
         queue = self.rq.queues[self.queue]
-        return queue.enqueue(self.func, *args, **kwargs)  # pyright: ignore
+        return queue.enqueue(self.func, *args, **kwargs)
+
+    def enqueue_at(self, when: datetime, /, *args: P.args, **kwargs: P.kwargs) -> Job:
+        """Like :meth:`enqueue`, but waits to run the function until the given
+        time. Calls :meth:`rq.Queue.enqueue_at`.
+
+        :param when: Wait until this time before running the job.
+        :param args: Any positional arguments accepted by the wrapped function.
+        :param kwargs: Any keyword arguments accepted by the wrapped function,
+            along with any keyword arguments that can be passed to
+            ``Queue.enqueue_at``.
+        """
+        queue = self.rq.queues[self.queue]
+        return queue.enqueue_at(when, self.func, *args, **kwargs)  # type: ignore[no-any-return]
+
+    def enqueue_in(
+        self, when: int | float | timedelta, /, *args: P.args, **kwargs: P.kwargs
+    ) -> Job:
+        """Like :meth:`enqueue`, but waits to run the function until the given
+        interval has passed. Calls :meth:`rq.Queue.enqueue_in`.
+
+        :param when: Wait for this interval (seconds or a ``timedelta``) before
+            running the job.
+        :param args: Any positional arguments accepted by the wrapped function.
+        :param kwargs: Any keyword arguments accepted by the wrapped function,
+            along with any keyword arguments that can be passed to
+            ``Queue.enqueue_in``.
+        """
+        if isinstance(when, (int, float)):
+            when = timedelta(seconds=when)
+
+        queue = self.rq.queues[self.queue]
+        return queue.enqueue_in(when, self.func, *args, **kwargs)
 
     def cron_register(
         self, interval: int | str, /, *args: P.args, **kwargs: P.kwargs

--- a/src/flask_rq/_job_wrapper.py
+++ b/src/flask_rq/_job_wrapper.py
@@ -42,7 +42,9 @@ class JobWrapper(t.Generic[P, R]):
         self.func: t.Callable[P, R] = func
         """The wrapped function.
 
-        :meta private:
+        This wrapper class cannot be passed to `rq.Queue.enqueue` etc.
+        Preferably, use the wrapper's methods instead; pass this if you cannot
+        in some situation.
         """
 
         update_wrapper(self, func)
@@ -70,3 +72,19 @@ class JobWrapper(t.Generic[P, R]):
         """
         queue = self.rq.queues[self.queue]
         return queue.enqueue(self.func, *args, **kwargs)  # pyright: ignore
+
+    def cron_register(
+        self, interval: int | str, /, *args: P.args, **kwargs: P.kwargs
+    ) -> None:
+        """Register a Cron schedule for the wrapped function to be periodically
+        added to the queue. Calls :meth:`.RQ.cron_register`.
+
+        :param interval: An int number of seconds, or a Cron string, descrbing
+            when the job is scheduled.
+
+        :param args: Any positional arguments accepted by the wrapped function.
+        :param kwargs: Any keyword arguments accepted by the wrapped function.
+        """
+        self.rq.cron_register(
+            self.func, interval, queue=self.queue, args=args, kwargs=kwargs
+        )

--- a/src/flask_rq/_make.py
+++ b/src/flask_rq/_make.py
@@ -19,12 +19,7 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
         "queue_connections", {}
     )
     conn_confs["default"] = config.get("connection", {})
-    conn_cls_conf: str | type[Redis] = config.get("connection_class", "redis.Redis")
-
-    if isinstance(conn_cls_conf, str):
-        conn_cls: type[Redis] = resolve_name(conn_cls_conf)
-    else:
-        conn_cls = conn_cls_conf
+    conn_cls = get_conn_cls(config.get("connection_class"))
 
     if (is_async := config.get("async", None)) is None:
         is_async = not app.testing
@@ -45,7 +40,7 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
                 conn_refs[name] = conn_conf
             else:
                 # This is a connection URL.
-                connections[name] = conn_cls.from_url(conn_conf)  # pyright: ignore
+                connections[name] = conn_cls.from_url(conn_conf)
         else:
             connections[name] = conn_cls(**conn_conf)
 
@@ -72,3 +67,23 @@ def make_queues(app: Flask | Quart) -> dict[str, Queue]:
         queues[name] = Queue(name, conn, is_async=is_async, job_class=job_class)
 
     return queues
+
+
+def get_conn_cls(ref: str | type[Redis] | None) -> type[Redis]:
+    if ref is None:
+        ref = "redis.Redis"
+
+    if isinstance(ref, str):
+        return resolve_name(ref)  # type: ignore[no-any-return]
+
+    return ref
+
+
+def make_default_connection(app: Flask | Quart) -> Redis:
+    conn_cls = get_conn_cls(app.config.get("RQ_CONNECTION_CLASS"))
+    conn_conf: dict[str, t.Any] | str = app.config.get("RQ_CONNECTION", {})
+
+    if isinstance(conn_conf, str):
+        return conn_cls.from_url(conn_conf)
+
+    return conn_cls(**conn_conf)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,3 +61,11 @@ def test_worker(worker_cls: Mock, app: Flask) -> None:
     work: Mock = worker.work
     work.assert_called()
     assert "burst" in work.call_args.kwargs
+
+
+@pytest.mark.usefixtures("rq")
+@patch("rq.cron.CronScheduler.start", spec=True)
+def test_cron(start_func: Mock, app: Flask) -> None:
+    runner = app.test_cli_runner()
+    runner.invoke(args=["rq", "cron"])
+    start_func.assert_called()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+from flask import Flask
+from rq import cron
+
+from flask_rq import RQ
+
+
+def job1(n: int = 1) -> None: ...
+
+
+@pytest.mark.parametrize(
+    ("conn_conf", "port"),
+    [("redis://localhost:24241", 24241), ({"port": 24242}, 24242)],
+)
+def test_make_scheduler(
+    app: Flask, conn_conf: str | dict[str, t.Any], port: int
+) -> None:
+    """Scheduler uses app config and default connection."""
+    app.config["RQ_CONNECTION"] = conn_conf
+    rq = RQ(app)
+
+    with app.app_context():
+        scheduler = rq.make_cron_scheduler()
+
+    assert scheduler.name == app.name
+    assert scheduler.connection.get_connection_kwargs()["port"] == port
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_global_register(request: pytest.FixtureRequest, rq: RQ) -> None:
+    """Global register is added to the scheduler."""
+    request.addfinalizer(lambda: cron._job_data_registry.clear())
+    cron.register(job1, "default", interval=10)
+    cron.register(job1, "low", cron="* * * * 1")
+    scheduler = rq.make_cron_scheduler()
+    jobs = scheduler.get_jobs()
+    assert len(jobs) == 2
+    assert jobs[0].interval == 10
+    assert jobs[1].cron == "* * * * 1"
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_instance_register(rq: RQ) -> None:
+    """Instance register is added to the scheduler."""
+    rq.cron_register(job1, 20, kwargs={"n": 2})
+    rq.cron_register(job1, "* * * * 2", queue="low", args=(3,))
+    scheduler = rq.make_cron_scheduler()
+    jobs = scheduler.get_jobs()
+    assert len(jobs) == 2
+    assert jobs[0].queue_name == "default"
+    assert jobs[0].interval == 20
+    assert jobs[0].kwargs["n"] == 2
+    assert jobs[1].queue_name == "low"
+    assert jobs[1].cron == "* * * * 2"
+    assert jobs[1].args[0] == 3
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_wrapper_register(rq: RQ) -> None:
+    """Wrapper register is added to the scheduler."""
+    wrapped_job1 = rq.job(job1)
+    wrapped_job1.cron_register(30, n=4)
+    scheduler = rq.make_cron_scheduler()
+    jobs = scheduler.get_jobs()
+    assert len(jobs) == 1
+    assert jobs[0].func == job1
+    assert jobs[0].queue_name == "default"
+    assert jobs[0].interval == 30
+    assert jobs[0].kwargs["n"] == 4

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import inspect
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 
 import pytest
+from rq.job import JobStatus
 
 from flask_rq import RQ
 
@@ -68,3 +72,22 @@ def test_job_low(rq: RQ) -> None:
     r = j.latest_result()
     assert r is not None
     assert r.return_value == 32
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_enqueue_at(rq: RQ) -> None:
+    job_mul = rq.job()(mul)
+    j = job_mul.enqueue_at(datetime.now(timezone.utc) + timedelta(days=1), 5, 10)
+    assert j.origin == "default"
+    assert j.get_status() == JobStatus.SCHEDULED
+    assert j.latest_result() is None
+
+
+@pytest.mark.parametrize("when", [60, timedelta(days=1)])
+@pytest.mark.usefixtures("app_ctx")
+def test_enqueue_in(rq: RQ, when: int | timedelta) -> None:
+    job_mul = rq.job()(mul)
+    j = job_mul.enqueue_in(when, 5, 10)
+    assert j.origin == "default"
+    assert j.get_status() == JobStatus.SCHEDULED
+    assert j.latest_result() is None

--- a/uv.lock
+++ b/uv.lock
@@ -551,7 +551,7 @@ typing = [
 requires-dist = [
     { name = "flask", extras = ["async"], specifier = ">=3.0" },
     { name = "quart", marker = "extra == 'quart'", specifier = ">=0.20" },
-    { name = "rq", specifier = ">=2.0" },
+    { name = "rq", specifier = ">=2.4" },
     { name = "typing-extensions", specifier = ">=4.12" },
 ]
 provides-extras = ["quart"]


### PR DESCRIPTION
Add support for registering Cron jobs and starting the scheduler. The scheduler will include any jobs registered globally with `rq.cron.register`, and also adds a `rq.cron_register` method to register jobs to the extension instance only.

Used the name `cron_register` instead of `cron` to match `cron.register`, and in case RQ's API changes in the future and we want to expose a full `cron` instance as an attribute.

The `cron_register` method uses the second positional argument for both the `interval` (`int`) and `cron` (`str`) arguments, and defaults the `queue_name` argument to `"default"`. The `@job` wrapper has a `cron_register` method.

The `flask rq cron` CLI command creates the scheduler, configures it and the jobs, and starts it. `rq.make_cron_scheduler` is available mostly to mirror `make_worker`, but is unlikely to be used directly. The scheduler uses the default `RQ_CONNECTION`, regardless of if `"default" is in `RQ_QUEUES`. The scheduler uses the Flask app name, rather than the hostname and UUID.

While working on this, I noticed that passing `@job` wrappers to `queue.enqueue` etc failed because RQ uses pickle and the wrapper has a reference to the extension which has `weakref` attributes. Add `JobWrapper.func` to the public API, and add a warning to the docs. Add `enqueue_at` and `enqueue_in` methods to the wrapper to avoid this. `enqueue_in` also supports passing an `int` for the interval, like cron does.

Also did a bit of other cleanup to the docs and code that I noticed along the way.