### PR TITLE
worker uses `subprocess` instead of `fork`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Unreleased
   scheduler.
 - Add `enqueue_at`, `enqueue_in`, and `cron_register` methods to the `@job`
   wrapper.
+- The worker runs jobs using `subprocess` and the `flask` CLI. This works on
+  Windows and macOS and avoids `fork` and `spawn`. {issue}`58`
 
 ## Version 0.3.3
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -9,6 +9,11 @@ run in an application context. This means that accessing `current_app`,
 databases, and other extensions will be available just like in view functions
 and CLI commands.
 
+Unlike RQ's worker, Flask-RQ's does not rely on `fork` or `spawn`, so it works
+on Windows and macOS in addition to Linux. Stopping the worker seems to be flaky
+on Windows; you can try adjusting `--worker-ttl` lower, or run in WSL or a
+container.
+
 See the [RQ docs] for more information on workers.
 
 [RQ docs]: https://python-rq.org/

--- a/src/flask_rq/_cli.py
+++ b/src/flask_rq/_cli.py
@@ -9,6 +9,8 @@ from flask import Flask
 from flask.cli import ScriptInfo as FlaskScriptInfo
 from rq import cli as orig_cli
 
+from ._worker import run_work_horse
+
 if t.TYPE_CHECKING:
     from quart import Quart
     from quart.cli import ScriptInfo as QuartScriptInfo
@@ -29,6 +31,7 @@ def make_cli(app: Flask | Quart) -> None:
     """
     group = app.cli.group("rq")(rq_group)
     group.command("worker", with_appcontext=True)(worker_cmd)
+    group.command("work-horse", with_appcontext=True, hidden=True)(work_horse_cmd)
     group.command("cron", with_appcontext=True)(cron_cmd)
     app.cli.add_command(group)
 
@@ -107,6 +110,30 @@ def worker_cmd(
         max_jobs=max_jobs,
         max_idle_time=max_idle_time,
         with_scheduler=with_scheduler,
+    )
+
+
+@click.argument("queue")
+@click.argument("worker")
+@click.argument("job")
+@click.argument("execution")
+@click.pass_obj
+def work_horse_cmd(
+    obj: RQ,
+    queue: str,
+    worker: str,
+    job: str,
+    execution: str,
+) -> None:
+    """Used by the worker to start a subprocess to run a job. Do not
+    call this directly.
+    """
+    run_work_horse(
+        rq_ext=obj,
+        queue_name=queue,
+        worker_key=worker,
+        job_id=job,
+        execution_id=execution,
     )
 
 

--- a/src/flask_rq/_extension.py
+++ b/src/flask_rq/_extension.py
@@ -9,12 +9,13 @@ from flask import Flask
 from flask.globals import app_ctx as flask_app_ctx
 from rq import cron
 from rq import Queue
-from rq import Worker
+from rq.worker import BaseWorker
 
 from ._cli import make_cli
 from ._job_wrapper import JobWrapper
 from ._make import make_default_connection
 from ._make import make_queues
+from ._worker import FlaskSubprocessWorker
 
 if t.TYPE_CHECKING:
     from quart import Quart
@@ -129,7 +130,7 @@ class RQ:
 
     def make_worker(
         self, queues: list[str] | tuple[str, ...] | None = None, **kwargs: t.Any
-    ) -> Worker:
+    ) -> BaseWorker:
         """Create a worker for the current application that will watch the
         configured queues and execute jobs in the application context.
 
@@ -153,7 +154,11 @@ class RQ:
             known_queues = self.queues
             worker_queues = tuple(known_queues[k] for k in queues)
 
-        return Worker(worker_queues, job_class=worker_queues[0].job_class, **kwargs)
+        return FlaskSubprocessWorker(
+            worker_queues,
+            job_class=worker_queues[0].job_class,
+            **kwargs,
+        )
 
     def cron_register(
         self,

--- a/src/flask_rq/_worker.py
+++ b/src/flask_rq/_worker.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+import typing as t
+
+from rq import Worker
+from rq.executions import Execution
+from rq.job import Job
+from rq.queue import Queue
+from rq.worker import SHUTDOWN_SIGNAL
+
+if t.TYPE_CHECKING:
+    from ._extension import RQ
+
+
+class FlaskSubprocessWorker(Worker):
+    """Start a subprocess with the ``flask`` CLI to run a job."""
+
+    _horse_proc: subprocess.Popen[bytes] | None = None
+
+    @property
+    def horse_proc(self) -> subprocess.Popen[bytes]:
+        return self._horse_proc  # type: ignore[return-value]
+
+    @horse_proc.setter
+    def horse_proc(self, value: subprocess.Popen[bytes]) -> None:
+        self._horse_proc = value
+        self._horse_pid = value.pid
+
+    def fork_work_horse(self, job: Job, queue: Queue) -> None:
+        # Find args leading up to the "rq" command.
+        for i, arg in enumerate(sys.orig_argv):
+            if arg == "rq":
+                rq_argv = sys.orig_argv[1 : i + 1]
+                break
+        else:
+            # Worker started from a script, not the ``flask rq`` command.
+            # Require FLASK_APP to load the app.
+            if "FLASK_APP" not in os.environ:
+                raise RuntimeError(
+                    "'FLASK_APP' env var must be set when not using 'flask' CLI."
+                )
+
+            rq_argv = ["-m", "flask", "rq"]
+
+        if sys.platform != "win32":
+            flags = 0
+        else:  # pragma: no cover
+            flags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+        assert self.execution is not None
+        self.horse_proc = subprocess.Popen(
+            [
+                sys.executable,
+                *rq_argv,
+                "work-horse",
+                queue.name,
+                self.key,
+                job.id,
+                self.execution.id,
+            ],
+            env=os.environ,
+            process_group=0,
+            creationflags=flags,
+        )
+        self.procline(f"Started {self.horse_proc.pid} at {time.time()}")  # type: ignore[no-untyped-call]
+
+    def wait_for_horse(
+        self,
+    ) -> tuple[int, int, t.Any] | tuple[None, None, None]:  # pragma: no cover
+        try:
+            if sys.platform != "win32":
+                import resource
+
+                rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+            else:
+                rusage = None
+
+            code = self.horse_proc.wait()
+            return self.horse_pid, code, rusage
+        except ChildProcessError:
+            return None, None, None
+
+    def kill_horse(
+        self, sig: signal.Signals = SHUTDOWN_SIGNAL
+    ) -> None:  # pragma: no cover
+        try:
+            self.horse_proc.send_signal(sig)
+            self.log.info(f"Worker {self.name}: sent {sig.name} to {self.horse_pid}")
+        except ProcessLookupError:
+            self.log.debug(f"Worker {self.name}: {self.horse_pid} is dead")
+
+
+def run_work_horse(
+    rq_ext: RQ,
+    queue_name: str,
+    worker_key: str,
+    job_id: str,
+    execution_id: str,
+) -> None:
+    """Recreate the worker and job execution in the subprocess. This is similar
+    to the code ``SpawnWorker`` passes to ``os.spawnv``.
+    """
+    queue = rq_ext.get_queue(queue_name)
+    assert queue.connection is not None
+    worker = FlaskSubprocessWorker.find_by_key(
+        worker_key,
+        connection=queue.connection,
+        job_class=queue.job_class,
+        queue_class=queue.__class__,
+        serializer=queue.serializer,
+    )
+    assert worker is not None
+    job = queue.fetch_job(job_id)
+    assert job is not None
+    worker.execution = Execution.fetch(
+        execution_id, job_id, connection=queue.connection
+    )
+    worker._is_horse = True
+    worker.main_work_horse(job, queue)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections.abc as cabc
+import shutil
 import subprocess
 import time
 import typing as t
@@ -24,8 +25,14 @@ def redis_port() -> int:
 def _start_redis(
     tmp_path_factory: pytest.TempPathFactory, redis_port: int
 ) -> cabc.Iterator[None]:
+    for name in "valkey-server", "redis-server", "memurai":  # pragma: no cover
+        if (exe := shutil.which(name)) is not None:
+            break
+    else:  # pragma: no cover
+        raise RuntimeError("Valkey, Redis, or Memurai must be installed.")
+
     proc = subprocess.Popen(
-        ["redis-server", "--port", str(redis_port)],
+        [exe, "--port", str(redis_port)],
         cwd=tmp_path_factory.mktemp("redis-server"),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,13 +8,19 @@ import click
 import pytest
 from flask import Flask
 from flask.globals import app_ctx
+from flask.testing import FlaskCliRunner
 from rq import cli as orig_cli
 
 from flask_rq import RQ
 from flask_rq._cli import from_rq_cmd
 
 
-def test_ctx_obj(app: Flask, rq: RQ) -> None:
+@pytest.fixture()
+def runner(app: Flask) -> FlaskCliRunner:
+    return app.test_cli_runner()
+
+
+def test_ctx_obj(app: Flask, rq: RQ, runner: FlaskCliRunner) -> None:
     recorded_app: t.Any | None = None
     recorded_obj: t.Any | None = None
     group = t.cast(click.Group, app.cli.commands["rq"])
@@ -27,7 +33,6 @@ def test_ctx_obj(app: Flask, rq: RQ) -> None:
         recorded_app = app_ctx.app
         recorded_obj = obj
 
-    runner = app.test_cli_runner()
     runner.invoke(args=["rq", "record"])
     assert recorded_app is app
     assert recorded_obj is rq
@@ -51,9 +56,8 @@ def test_from_rq_cmd_override_doc() -> None:
 
 
 @pytest.mark.usefixtures("rq")
-@patch("flask_rq._extension.Worker", spec=True)
-def test_worker(worker_cls: Mock, app: Flask) -> None:
-    runner = app.test_cli_runner()
+@patch("flask_rq._extension.FlaskSubprocessWorker", spec=True)
+def test_worker(worker_cls: Mock, runner: FlaskCliRunner) -> None:
     runner.invoke(args=["rq", "worker"])
     worker_cls.assert_called()
     assert "default_result_ttl" in worker_cls.call_args.kwargs
@@ -64,8 +68,21 @@ def test_worker(worker_cls: Mock, app: Flask) -> None:
 
 
 @pytest.mark.usefixtures("rq")
+@patch("flask_rq._cli.run_work_horse", spec=True)
+def test_work_horse(run: Mock, rq: RQ, runner: FlaskCliRunner) -> None:
+    runner.invoke(args=["rq", "work-horse", "a", "b", "c", "d"])
+    run.assert_called()
+    assert run.call_args.kwargs == {
+        "rq_ext": rq,
+        "queue_name": "a",
+        "worker_key": "b",
+        "job_id": "c",
+        "execution_id": "d",
+    }
+
+
+@pytest.mark.usefixtures("rq")
 @patch("rq.cron.CronScheduler.start", spec=True)
-def test_cron(start_func: Mock, app: Flask) -> None:
-    runner = app.test_cli_runner()
+def test_cron(start_func: Mock, runner: FlaskCliRunner) -> None:
     runner.invoke(args=["rq", "cron"])
     start_func.assert_called()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,61 +1,16 @@
 from __future__ import annotations
 
-import typing as t
+import os
+import sys
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
-from flask import current_app as flask_current_app
-from flask import Flask
-from quart import current_app as quart_current_app
-from quart import Quart
+from rq.executions import Execution
 
 from flask_rq import RQ
-
-
-@pytest.fixture
-def config(config: dict[str, t.Any]) -> dict[str, t.Any]:
-    config["FIND"] = "found"
-    config["RQ_ASYNC"] = True
-    return config
-
-
-def flask_sync_job() -> str:  # pragma: no cover
-    return flask_current_app.config["FIND"]  # type: ignore[no-any-return]
-
-
-async def flask_async_job() -> str:  # pragma: no cover
-    return flask_current_app.config["FIND"]  # type: ignore[no-any-return]
-
-
-@pytest.mark.parametrize("func", [flask_sync_job, flask_async_job])
-def test_flask(app: Flask, rq: RQ, func: t.Callable[[], str]) -> None:
-    with app.app_context():
-        job = rq.queue.enqueue(func)
-        worker = rq.make_worker()
-
-    worker.work(burst=True)
-    r = job.latest_result()
-    assert r is not None
-    assert r.return_value == "found"
-
-
-async def quart_async_job() -> str:  # pragma: no cover
-    return quart_current_app.config["FIND"]  # type: ignore[no-any-return]
-
-
-def quart_sync_job() -> str:  # pragma: no cover
-    return quart_current_app.config["FIND"]  # type: ignore[no-any-return]
-
-
-@pytest.mark.parametrize("func", [quart_async_job, quart_sync_job])
-async def test_quart(quart_app: Quart, rq: RQ, func: t.Callable[[], str]) -> None:
-    async with quart_app.app_context():
-        job = rq.queue.enqueue(func)
-        worker = rq.make_worker()
-
-    worker.work(burst=True)
-    r = job.latest_result()
-    assert r is not None
-    assert r.return_value == "found"
+from flask_rq._worker import FlaskSubprocessWorker
+from flask_rq._worker import run_work_horse
 
 
 @pytest.mark.usefixtures("app_ctx")
@@ -84,3 +39,81 @@ def test_worker_no_default(rq: RQ) -> None:
     worker = rq.make_worker(["low", "high"])
     assert len(worker.queues) == 2
     assert worker.connection is rq.queues["low"].connection
+
+
+@pytest.mark.parametrize(
+    ("argv", "expect"),
+    [
+        (["/tmp/flask", "rq", "worker"], ["/tmp/flask"]),
+        (["-m", "flask", "rq", "worker"], ["-m", "flask"]),
+        (["script.py"], ["-m", "flask"]),
+    ],
+)
+@pytest.mark.usefixtures("app_ctx")
+def test_fork(rq: RQ, argv: list[str], expect: list[str]) -> None:
+    worker = rq.make_worker()
+    assert isinstance(worker, FlaskSubprocessWorker)
+    job = MagicMock(spec=rq.queue.job_class)
+    job.id = "job-test"
+    execution = MagicMock(spec=Execution)
+    execution.id = "execution-test"
+    worker.execution = execution
+
+    with (
+        patch.object(sys, "orig_argv", ["python", *argv]),
+        patch.dict(os.environ, {"FLASK_APP": "test"}),
+        patch("subprocess.Popen", spec=True) as mock_popen,
+        patch.object(worker, "procline"),
+    ):
+        mock_popen.return_value.pid = 50
+        worker.fork_work_horse(job, rq.queue)
+
+    assert mock_popen.call_args is not None
+    assert mock_popen.call_args.args[0] == [
+        sys.executable,
+        *expect,
+        "rq",
+        "work-horse",
+        "default",
+        worker.key,
+        "job-test",
+        "execution-test",
+    ]
+    assert worker._horse_pid == 50
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_fork_no_app(rq: RQ) -> None:
+    worker = rq.make_worker()
+    assert isinstance(worker, FlaskSubprocessWorker)
+
+    with (
+        pytest.raises(RuntimeError, match="FLASK_APP"),
+        patch.object(sys, "orig_argv", ["python", "script.py"]),
+    ):
+        worker.fork_work_horse(None, None)  # type: ignore[arg-type]
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_run_work_horse(rq: RQ) -> None:
+    queue = rq.queue
+    worker = MagicMock(spec=FlaskSubprocessWorker)
+    job = MagicMock(spec=queue.job_class)
+    execution = MagicMock(spec=Execution)
+
+    with (
+        patch.object(FlaskSubprocessWorker, "find_by_key", return_value=worker),
+        patch.object(queue, "fetch_job", return_value=job),
+        patch.object(Execution, "fetch", return_value=execution),
+    ):
+        run_work_horse(
+            rq_ext=rq,
+            queue_name="default",
+            worker_key="worker-test",
+            job_id="job-test",
+            execution_id="execution-test",
+        )
+
+    assert worker.execution is execution
+    assert worker._is_horse
+    worker.main_work_horse.assert_called_once_with(job, queue)


### PR DESCRIPTION
This adds a hidden (private) `flask rq work-horse` command. This calls a function that sets up the job using code similar to what RQ's `SpawnWorker` passes to `spawn`. However, since it uses runs through the Flask CLI, the Flask app context remains available in the subprocess.

It supports `python -m flask rq`, `flask rq`, or `python script.py`. In the first two cases, `-A app` or `FLASK_APP` env var can be used to load the app. In the last case, `FLASK_APP` must be set, since it still uses `-m flask` in the subprocess.

Removed some redundant tests that started a real worker unnecessarily, when the code was already tested in the queue tests.

fixes #58 